### PR TITLE
forgot an extra :

### DIFF
--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -33,7 +33,7 @@ const SignInContainer = styled(Stack)(({ theme }) => ({
     [theme.breakpoints.up('sm')]: {
         padding: theme.spacing(4),
     },
-    '&:before': {
+    '&::before': {
         content: '""',
         display: 'block',
         position: 'absolute',


### PR DESCRIPTION
forgot an extra colon in the `&::before` selector